### PR TITLE
feat(alerts) include new alertDefinition action fields

### DIFF
--- a/graphql/alerts.graphql
+++ b/graphql/alerts.graphql
@@ -1,10 +1,13 @@
 query getAlertDefinitionById($id: ID!) {
   alertQueries {
-    alertDefinitions(filter: {id: $id}) {
+    alertDefinitions(filter: { id: $id }) {
       alertDefinitions {
         actions {
           configurationIds
           type
+          receivingType
+          includeDetails
+          resendIntervalSeconds
         }
         triggerResetActions
         conditionType
@@ -51,7 +54,6 @@ query getAlertDefinitionById($id: ID!) {
             namespace
             query
           }
-
         }
         description
         enabled
@@ -82,6 +84,9 @@ mutation createAlertDefinitionMutation($definition: AlertDefinitionInput!) {
       actions {
         configurationIds
         type
+        receivingType
+        includeDetails
+        resendIntervalSeconds
       }
       flatCondition {
         id
@@ -109,40 +114,43 @@ mutation updateAlertDefinitionMutation(
       definition: $definition
       id: $updateAlertDefinitionId
     ) {
-        actions {
-          configurationIds
-          type
-        }
-        triggerResetActions
-        conditionType
-        flatCondition {
-          id
-          links {
-            name
-            values
-          }
-          value {
-            fieldName
-            operator
-            type
-            query
-          }
-        }
-        description
-        enabled
+      actions {
+        configurationIds
+        type
+        receivingType
+        includeDetails
+        resendIntervalSeconds
+      }
+      triggerResetActions
+      conditionType
+      flatCondition {
         id
-        name
-        organizationId
-        severity
-        triggered
-        triggeredTime
-        targetEntityTypes
-        muteInfo {
-          muted
-          until
+        links {
+          name
+          values
         }
-        userId
-        runbookLink
+        value {
+          fieldName
+          operator
+          type
+          query
+        }
+      }
+      description
+      enabled
+      id
+      name
+      organizationId
+      severity
+      triggered
+      triggeredTime
+      targetEntityTypes
+      muteInfo {
+        muted
+        until
+      }
+      userId
+      runbookLink
     }
   }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -341,11 +341,23 @@ type AlertAction {
   Notification service type (email, MS Teams, Slack, webhook, ...).
   """
   type: String!
-
   """
   Notification configuration IDs.
   """
   configurationIds: [ID!]!
+  """
+  Type of notification receiving
+  """
+  receivingType: NotificationReceivingType
+  """
+  A flag indicates whether include logs/details to notification or not.
+  """
+  includeDetails: Boolean
+  """
+  How often should the notification be resent in case alert keeps being triggered. Null means notification is sent
+  only once.
+  """
+  resendIntervalSeconds: Int
 }
 
 type AlertActionDeletedByCnsEvent implements AlertManagementEvent {
@@ -366,11 +378,23 @@ input AlertActionInput {
   Type of a notification service
   """
   type: String!
-
   """
   List of notification configuration IDs
   """
   configurationIds: [ID!]!
+  """
+  Type of notification receiving
+  """
+  receivingType: NotificationReceivingType = NOT_SPECIFIED
+  """
+  A flag indicates whether include logs/details to notification or not.
+  """
+  includeDetails: Boolean = true
+  """
+  How often should the notification be resent in case alert keeps being triggered. Null means notification is sent
+  only once.
+  """
+  resendIntervalSeconds: Int
 }
 
 """
@@ -670,7 +694,6 @@ input AlertConditionNodeInput {
   Condition node ID.
   """
   id: Int!
-
   """
   Node (operator) type. Supported values:
   - `aggregationOperator` (child of `binaryOperator`)
@@ -684,7 +707,6 @@ input AlertConditionNodeInput {
   - `relationshipOperator` (root, or child of `logicalOperator`, `unaryOperator`)
   """
   type: String!
-
   """
   Operator for combining operands. Supported values:
   - For aggregationOperator: `COUNT`, `MIN`, `MAX`, `AVG`, `SUM`, `LAST`
@@ -694,56 +716,54 @@ input AlertConditionNodeInput {
   - For relationshipOperator: null
   """
   operator: String
-
   """
   Ordered list of child condition nodes IDs.
   """
   operandIds: [Int!]
-
   """
   Entity filter for `metricField`, `queryField` and 'scopeField' nodes. When defined (not null), node is scoped to entity.
   """
   entityFilter: AlertConditionNodeEntityFilterInput
-
   """
   Measurement filter for metric tags
   """
   metricFilter: AlertFilterExpressionInput
-
   """
   Entity metric field for `metricField` nodes
   """
   fieldName: String
-
   """
   Data type for `constantValue` nodes. Supported values: `boolean`, `number`, `string`
   """
   dataType: String
-
   """
   String representation of value for `constantValue` nodes.
   """
   value: String
-
   """
   String representation of values for `constantValue` nodes in case of 'IN' operator
   """
   values: [String!]
-
   """
   Query specification for `queryField` nodes.
   """
   query: String
-
   """
   Events/logs namespace (in Chainsaw) for `queryField` nodes.
   """
   namespace: String
-
   """
   Group by specific metric tag(s).
   """
   groupByMetricTag: [String!]
+  """
+  Fallback static threshold value to be used if dynamic threshold data are not available.
+  """
+  fallbackValue: String
+  """
+  Log group IDs according to which Alert definition is scoped.
+  """
+  logGroupIds: [String!]
 }
 
 """
@@ -992,48 +1012,58 @@ type AlertDefinitionEventData {
   targetEntityTypes: [String!]
 }
 
+"""
+Part of Alert action. Type of notification receiving.
+"""
+enum NotificationReceivingType {
+  NOT_SPECIFIED
+  INDIVIDUAL
+  AGGREGATED
+}
+# noinspection GraphQLTypeRedefinition
 input AlertDefinitionInput {
   """
   Alert definition name
   """
   name: String!
-
   """
   Alert definition description
   """
   description: String
-
   """
   Alert runbook link
   """
   runbookLink: String
-
   """
   Alert definition severity
   """
   severity: AlertSeverity!
-
   """
   Enabled whether Alert definition shall be evaluated
   """
   enabled: Boolean!
-
   """
   Ordered list of condition nodes representing the flatten condition tree.
   The first item is the tree root.
   """
   condition: [AlertConditionNodeInput!]!
-
   """
   List of alert actions that shall be triggered in case of alert **FIRING**
   """
   actions: [AlertActionInput!]
-
   """
   A flag indicating whether to send a notification when active alert returns to normal.
   It will be set to *false* if not specified.
   """
   triggerResetActions: Boolean
+  """
+  Number of seconds during which the condition must be continually met before an alert is triggered.
+  """
+  triggerDelaySeconds: Int
+  """
+  Id of an alert template used to create this alert.
+  """
+  templateId: String
 }
 
 type AlertDefinitionManualResetEvent implements AlertManagementEvent {

--- a/pkg/client/genqlient_generated.go
+++ b/pkg/client/genqlient_generated.go
@@ -17,6 +17,13 @@ type AlertActionInput struct {
 	Type string `json:"type"`
 	// List of notification configuration IDs
 	ConfigurationIds []string `json:"configurationIds"`
+	// Type of notification receiving
+	ReceivingType *NotificationReceivingType `json:"receivingType"`
+	// A flag indicates whether include logs/details to notification or not.
+	IncludeDetails *bool `json:"includeDetails"`
+	// How often should the notification be resent in case alert keeps being triggered. Null means notification is sent
+	// only once.
+	ResendIntervalSeconds *int `json:"resendIntervalSeconds"`
 }
 
 // GetType returns AlertActionInput.Type, and is useful for accessing the field via an interface.
@@ -24,6 +31,15 @@ func (v *AlertActionInput) GetType() string { return v.Type }
 
 // GetConfigurationIds returns AlertActionInput.ConfigurationIds, and is useful for accessing the field via an interface.
 func (v *AlertActionInput) GetConfigurationIds() []string { return v.ConfigurationIds }
+
+// GetReceivingType returns AlertActionInput.ReceivingType, and is useful for accessing the field via an interface.
+func (v *AlertActionInput) GetReceivingType() *NotificationReceivingType { return v.ReceivingType }
+
+// GetIncludeDetails returns AlertActionInput.IncludeDetails, and is useful for accessing the field via an interface.
+func (v *AlertActionInput) GetIncludeDetails() *bool { return v.IncludeDetails }
+
+// GetResendIntervalSeconds returns AlertActionInput.ResendIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *AlertActionInput) GetResendIntervalSeconds() *int { return v.ResendIntervalSeconds }
 
 type AlertConditionMatchFieldRuleInput struct {
 	// Field name to apply filtering rule on
@@ -132,6 +148,10 @@ type AlertConditionNodeInput struct {
 	Namespace *string `json:"namespace"`
 	// Group by specific metric tag(s).
 	GroupByMetricTag []string `json:"groupByMetricTag"`
+	// Fallback static threshold value to be used if dynamic threshold data are not available.
+	FallbackValue *string `json:"fallbackValue"`
+	// Log group IDs according to which Alert definition is scoped.
+	LogGroupIds []string `json:"logGroupIds"`
 }
 
 // GetId returns AlertConditionNodeInput.Id, and is useful for accessing the field via an interface.
@@ -177,6 +197,12 @@ func (v *AlertConditionNodeInput) GetNamespace() *string { return v.Namespace }
 // GetGroupByMetricTag returns AlertConditionNodeInput.GroupByMetricTag, and is useful for accessing the field via an interface.
 func (v *AlertConditionNodeInput) GetGroupByMetricTag() []string { return v.GroupByMetricTag }
 
+// GetFallbackValue returns AlertConditionNodeInput.FallbackValue, and is useful for accessing the field via an interface.
+func (v *AlertConditionNodeInput) GetFallbackValue() *string { return v.FallbackValue }
+
+// GetLogGroupIds returns AlertConditionNodeInput.LogGroupIds, and is useful for accessing the field via an interface.
+func (v *AlertConditionNodeInput) GetLogGroupIds() []string { return v.LogGroupIds }
+
 type AlertDefinitionInput struct {
 	// Alert definition name
 	Name string `json:"name"`
@@ -196,6 +222,10 @@ type AlertDefinitionInput struct {
 	// A flag indicating whether to send a notification when active alert returns to normal.
 	// It will be set to *false* if not specified.
 	TriggerResetActions *bool `json:"triggerResetActions"`
+	// Number of seconds during which the condition must be continually met before an alert is triggered.
+	TriggerDelaySeconds *int `json:"triggerDelaySeconds"`
+	// Id of an alert template used to create this alert.
+	TemplateId *string `json:"templateId"`
 }
 
 // GetName returns AlertDefinitionInput.Name, and is useful for accessing the field via an interface.
@@ -221,6 +251,12 @@ func (v *AlertDefinitionInput) GetActions() []AlertActionInput { return v.Action
 
 // GetTriggerResetActions returns AlertDefinitionInput.TriggerResetActions, and is useful for accessing the field via an interface.
 func (v *AlertDefinitionInput) GetTriggerResetActions() *bool { return v.TriggerResetActions }
+
+// GetTriggerDelaySeconds returns AlertDefinitionInput.TriggerDelaySeconds, and is useful for accessing the field via an interface.
+func (v *AlertDefinitionInput) GetTriggerDelaySeconds() *int { return v.TriggerDelaySeconds }
+
+// GetTemplateId returns AlertDefinitionInput.TemplateId, and is useful for accessing the field via an interface.
+func (v *AlertDefinitionInput) GetTemplateId() *string { return v.TemplateId }
 
 // Generic filtering input.
 type AlertFilterExpressionInput struct {
@@ -677,6 +713,15 @@ func (v *LayoutInput) GetWidth() int { return v.Width }
 
 // GetHeight returns LayoutInput.Height, and is useful for accessing the field via an interface.
 func (v *LayoutInput) GetHeight() int { return v.Height }
+
+// Part of Alert action. Type of notification receiving.
+type NotificationReceivingType string
+
+const (
+	NotificationReceivingTypeNotSpecified NotificationReceivingType = "NOT_SPECIFIED"
+	NotificationReceivingTypeIndividual   NotificationReceivingType = "INDIVIDUAL"
+	NotificationReceivingTypeAggregated   NotificationReceivingType = "AGGREGATED"
+)
 
 type ProbeLocationInput struct {
 	Type ProbeLocationType `json:"type"`
@@ -1444,6 +1489,13 @@ type createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAler
 	ConfigurationIds []string `json:"configurationIds"`
 	// Notification service type (email, MS Teams, Slack, webhook, ...).
 	Type string `json:"type"`
+	// Type of notification receiving
+	ReceivingType *NotificationReceivingType `json:"receivingType"`
+	// A flag indicates whether include logs/details to notification or not.
+	IncludeDetails *bool `json:"includeDetails"`
+	// How often should the notification be resent in case alert keeps being triggered. Null means notification is sent
+	// only once.
+	ResendIntervalSeconds *int `json:"resendIntervalSeconds"`
 }
 
 // GetConfigurationIds returns createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction.ConfigurationIds, and is useful for accessing the field via an interface.
@@ -1454,6 +1506,21 @@ func (v *createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActions
 // GetType returns createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction.Type, and is useful for accessing the field via an interface.
 func (v *createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction) GetType() string {
 	return v.Type
+}
+
+// GetReceivingType returns createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction.ReceivingType, and is useful for accessing the field via an interface.
+func (v *createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction) GetReceivingType() *NotificationReceivingType {
+	return v.ReceivingType
+}
+
+// GetIncludeDetails returns createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction.IncludeDetails, and is useful for accessing the field via an interface.
+func (v *createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction) GetIncludeDetails() *bool {
+	return v.IncludeDetails
+}
+
+// GetResendIntervalSeconds returns createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction.ResendIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionActionsAlertAction) GetResendIntervalSeconds() *int {
+	return v.ResendIntervalSeconds
 }
 
 // createAlertDefinitionMutationAlertMutationsCreateAlertDefinitionFlatConditionFlatAlertConditionExpression includes the requested fields of the GraphQL type FlatAlertConditionExpression.
@@ -2378,6 +2445,13 @@ type getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAle
 	ConfigurationIds []string `json:"configurationIds"`
 	// Notification service type (email, MS Teams, Slack, webhook, ...).
 	Type string `json:"type"`
+	// Type of notification receiving
+	ReceivingType *NotificationReceivingType `json:"receivingType"`
+	// A flag indicates whether include logs/details to notification or not.
+	IncludeDetails *bool `json:"includeDetails"`
+	// How often should the notification be resent in case alert keeps being triggered. Null means notification is sent
+	// only once.
+	ResendIntervalSeconds *int `json:"resendIntervalSeconds"`
 }
 
 // GetConfigurationIds returns getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction.ConfigurationIds, and is useful for accessing the field via an interface.
@@ -2388,6 +2462,21 @@ func (v *getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResul
 // GetType returns getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction.Type, and is useful for accessing the field via an interface.
 func (v *getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction) GetType() string {
 	return v.Type
+}
+
+// GetReceivingType returns getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction.ReceivingType, and is useful for accessing the field via an interface.
+func (v *getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction) GetReceivingType() *NotificationReceivingType {
+	return v.ReceivingType
+}
+
+// GetIncludeDetails returns getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction.IncludeDetails, and is useful for accessing the field via an interface.
+func (v *getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction) GetIncludeDetails() *bool {
+	return v.IncludeDetails
+}
+
+// GetResendIntervalSeconds returns getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction.ResendIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionActionsAlertAction) GetResendIntervalSeconds() *int {
+	return v.ResendIntervalSeconds
 }
 
 // getAlertDefinitionByIdAlertQueriesAlertDefinitionsAlertDefinitionsResultAlertDefinitionsAlertDefinitionFlatConditionFlatAlertConditionExpression includes the requested fields of the GraphQL type FlatAlertConditionExpression.
@@ -9799,6 +9888,13 @@ type updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAler
 	ConfigurationIds []string `json:"configurationIds"`
 	// Notification service type (email, MS Teams, Slack, webhook, ...).
 	Type string `json:"type"`
+	// Type of notification receiving
+	ReceivingType *NotificationReceivingType `json:"receivingType"`
+	// A flag indicates whether include logs/details to notification or not.
+	IncludeDetails *bool `json:"includeDetails"`
+	// How often should the notification be resent in case alert keeps being triggered. Null means notification is sent
+	// only once.
+	ResendIntervalSeconds *int `json:"resendIntervalSeconds"`
 }
 
 // GetConfigurationIds returns updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction.ConfigurationIds, and is useful for accessing the field via an interface.
@@ -9809,6 +9905,21 @@ func (v *updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActions
 // GetType returns updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction.Type, and is useful for accessing the field via an interface.
 func (v *updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction) GetType() string {
 	return v.Type
+}
+
+// GetReceivingType returns updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction.ReceivingType, and is useful for accessing the field via an interface.
+func (v *updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction) GetReceivingType() *NotificationReceivingType {
+	return v.ReceivingType
+}
+
+// GetIncludeDetails returns updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction.IncludeDetails, and is useful for accessing the field via an interface.
+func (v *updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction) GetIncludeDetails() *bool {
+	return v.IncludeDetails
+}
+
+// GetResendIntervalSeconds returns updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction.ResendIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionActionsAlertAction) GetResendIntervalSeconds() *int {
+	return v.ResendIntervalSeconds
 }
 
 // updateAlertDefinitionMutationAlertMutationsUpdateAlertDefinitionFlatConditionFlatAlertConditionExpression includes the requested fields of the GraphQL type FlatAlertConditionExpression.
@@ -10339,6 +10450,9 @@ mutation createAlertDefinitionMutation ($definition: AlertDefinitionInput!) {
 			actions {
 				configurationIds
 				type
+				receivingType
+				includeDetails
+				resendIntervalSeconds
 			}
 			flatCondition {
 				id
@@ -10945,6 +11059,9 @@ query getAlertDefinitionById ($id: ID!) {
 				actions {
 					configurationIds
 					type
+					receivingType
+					includeDetails
+					resendIntervalSeconds
 				}
 				triggerResetActions
 				conditionType
@@ -11421,6 +11538,9 @@ mutation updateAlertDefinitionMutation ($definition: AlertDefinitionInput!, $upd
 			actions {
 				configurationIds
 				type
+				receivingType
+				includeDetails
+				resendIntervalSeconds
 			}
 			triggerResetActions
 			conditionType


### PR DESCRIPTION
- In `schema.graphql` updated `AlertAction` to include new fields. `receivingType`, `includeDetails`, and `resendIntervalSeconds`. 
- Added the `NotificationReceivingType` enum. 
- Updating `AlertDefinitionInput` to include `triggerDelaySeconds`, and `templateId`

- Updating `alerts.graphql` get, create, and update to include new `AlertAction` fields.