### PR TITLE
Add specific errors for alerts

### DIFF
--- a/pkg/client/alerts_test.go
+++ b/pkg/client/alerts_test.go
@@ -278,8 +278,10 @@ func TestUpdateAlert(t *testing.T) {
 			t.Errorf("Request input = %+v, want %+v", got, want)
 		}
 
-		sendGraphQLResponse(t, w, updateAlertDefinitionMutationAlertMutations{
-			UpdateAlertDefinition: mockUpdateAlertDefinitionResult(gqlInput.UpdateAlertDefinitionId, got.Name, *got.Description),
+		sendGraphQLResponse(t, w, updateAlertDefinitionMutationResponse{
+			AlertMutations: updateAlertDefinitionMutationAlertMutations{
+				UpdateAlertDefinition: mockUpdateAlertDefinitionResult(gqlInput.UpdateAlertDefinitionId, got.Name, *got.Description),
+			},
 		})
 	})
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,6 +24,8 @@ const (
 )
 
 var (
+	ErrUnknown     = errors.New("unknown error")
+	ErrNotFound    = errors.New("not found")
 	ErrEntityIdNil = errors.New("entity id is nil")
 )
 


### PR DESCRIPTION
Adds specific errors when the alert is not found. Note that this is based on whether something is returned, rather on real error analysis. This is fine for now—especially given that the server does not return a code that can be programmatically consumed, but a string that we'd have to parse—but there's room to refine it later.